### PR TITLE
feat: support `npm:` specifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,32 +19,6 @@ jobs:
 
   release:
     name: Release
-    if: ${{ github.repository_owner == 'hasundue' }}
+    if: github.repository_owner == 'hasundue'
     needs: test
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Deno
-        uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.32.3 # @denopendabot denoland/deno
-
-      - name: Install ghlog
-        run: deno install -A https://pax.deno.dev/hasundue/ghlog/ghlog.ts 
-
-      - name: Generate Release Notes
-        run: ghlog ${{ github.repository }} -s | xargs -I {tag} echo "NEW_TAG={tag}" >> $GITHUB_ENV
-
-      - name: Create a release
-        id: release
-        if: ${{ env.NEW_TAG != 'UNRELEASED' }}
-        uses: ncipollo/release-action@v1
-        with:
-          tag: '${{ env.NEW_TAG }}'
-          name: '${{ env.NEW_TAG }}'
-          bodyFile: 'CHANGELOG.md'
-          draft: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/release.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  workflow_call:
+    outputs:
+      released:
+        description: true if released
+        value: ${{ jobs.release.outputs.released }}
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    outputs:
+      released: ${{ steps.run.outputs.released }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.5.0
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.32.2 # @denopendabot denoland/deno
+
+      - name: Run denomantic-release
+        id: run
+        run: >
+          deno run -q --allow-env --allow-net --allow-write
+          https://deno.land/x/denomantic_release@0.8.1/cli.ts
+          ${{ github.repository }}
+          --token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Denopendabot 
+        if: ${{ steps.run.outputs.needs_update }}
+        uses: ./
+        with:
+          mode: app
+          release: ${{ steps.run.outputs.version }}
+          auto-merge: any

--- a/nublar.ts
+++ b/nublar.ts
@@ -63,6 +63,9 @@ const getScriptList = (options: GlobalOptions): Script[] => {
   const scripts: Script[] = [];
 
   for (const entry of Deno.readDirSync(resolve(scriptDir))) {
+    if (entry.name === "deno" || entry.name.startsWith(".")) {
+      continue;
+    }
     const content = Deno.readTextFileSync(join(scriptDir, entry.name));
     const versionMatch = content.match(/(?<=[a-z]@)[v?\d\.]+(?=\/)/);
 

--- a/nublar.ts
+++ b/nublar.ts
@@ -7,7 +7,7 @@ import { udd } from "https://deno.land/x/udd@0.8.2/mod.ts";
 
 new Command()
   .name("nublar")
-  .version("0.2.0")
+  .version("0.2.0") // @denopendabot hasundue/nublar
   .description(
     "A command-line tool to manage your Deno scripts installed via `deno install`.",
   )

--- a/nublar.ts
+++ b/nublar.ts
@@ -109,10 +109,15 @@ async function update(
   const all = getScriptList(options);
 
   const scripts = scriptNames.length
-    ? all.filter((script) => scriptNames.find((name) => name === script.name))
+    ? all.filter((script) => scriptNames.includes(script.name))
     : all;
 
+  let found = false;
+
   for (const script of scripts) {
+    if (!script.version) {
+      continue;
+    }
     const results = await udd(script.path, {
       dryRun: options?.check,
       quiet: true,
@@ -121,11 +126,15 @@ async function update(
     for (const result of results) {
       if (result.message) {
         const action = options.check ? "Found" : "Updated";
-        const newVersion = result.message!.match(/^[v\d\.]+/);
+        const newVersion = result.message.match(/^[v\d\.]+/);
         console.log(
           `${action} ${script.name} ${script.version} => ${newVersion}`,
         );
+        found = true;
       }
     }
+  }
+  if (!found) {
+    console.log("No updates found.");
   }
 }


### PR DESCRIPTION
- build: use denopenabot to update the version number
- refactor: check first if the script is valid
- refactor: use udd to get version
- refactor: use includes instead of find
