### PR TITLE
give scripts with defined versions a higher priority

### DIFF
--- a/nublar.ts
+++ b/nublar.ts
@@ -108,7 +108,9 @@ async function getScriptList(options: GlobalOptions) {
 async function list(options: GlobalOptions) {
   const scripts = await getScriptList(options);
   const table = Table.from(
-    scripts.map((script) => [script.name, script.version]),
+    scripts.map((script) => [script.name, script.version])
+      // give scripts with definied version a higher priority
+      .sort(([_n1, _v1], [_n2, v2]) => v2 ? 1 : -1),
   );
   console.log(table.toString());
 }


### PR DESCRIPTION
I think it makes sense, since nublar can update those

![image](https://github.com/hasundue/nublar/assets/22427111/53073e72-4ec0-4e24-be6a-3c97d7d55b2f)
